### PR TITLE
fix: add 'svelte' field in package.json to fix unknown file extension…

### DIFF
--- a/packages/svelte-tel-input/package.json
+++ b/packages/svelte-tel-input/package.json
@@ -97,6 +97,7 @@
 			]
 		}
 	},
+	"svelte": "./dist/index.js",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR fixes the unknown file extension '.svelte' error by adding the svelte field in package.json