### PR TITLE
packaging: follow sveltekit packaging guidelines closer

### DIFF
--- a/.changeset/ten-eggs-design.md
+++ b/.changeset/ten-eggs-design.md
@@ -1,0 +1,5 @@
+---
+'svelte-tel-input': patch
+---
+
+packaging: abide closer to svelte spec

--- a/packages/svelte-tel-input/package.json
+++ b/packages/svelte-tel-input/package.json
@@ -103,8 +103,7 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js",
-			"default": "./dist/index.js"
+			"svelte": "./dist/index.js"
 		},
 		"./types": {
 			"types": "./dist/types/index.d.ts",


### PR DESCRIPTION
this is what I had to change in the package.json to get rid of the warning 
in the issue https://github.com/gyurielf/svelte-tel-input/issues/184
I've used https://kit.svelte.dev/docs/packaging
where they don't talk about having both a svelte and a default. I'm guessing this is creating a confusion somewhere.
I completely understand if you would rather not commit this, I thought I would just contribute it and leave the decision to merging it to you.