### PR TITLE
feat: Add `$$restProps` and `el` prop

### DIFF
--- a/packages/svelte-tel-input/src/lib/components/input/TelInput.svelte
+++ b/packages/svelte-tel-input/src/lib/components/input/TelInput.svelte
@@ -54,6 +54,8 @@
 	export let valid = true;
 	/** You can turn on and off certain features by this object */
 	export let options: TelInputOptions = defaultOptions;
+	/** Binding to the underlying `<input>` element */
+	export let el: HTMLInputElement | undefined = undefined;
 
 	let inputValue = value;
 	let prevCountry = country;
@@ -194,6 +196,8 @@
 </script>
 
 <input
+	{...$$restProps}
+	bind:this={el}
 	{autocomplete}
 	class={classes}
 	{disabled}


### PR DESCRIPTION
Adds `$$restProps` and `el` prop to allow for more ergonomic use.

- Would fix #220
- Adds `el` to allow for interactions with the underlying `<input>`. This enables you to do things like programmatically focusing the input.
- Adding `$$restProps` should also resolve #215