### PR TITLE
fix: variable typo, isValid

### DIFF
--- a/packages/svelte-tel-input/README.md
+++ b/packages/svelte-tel-input/README.md
@@ -79,7 +79,7 @@ _Snippet would be too long_ - [Example](https://github.com/gyurielf/svelte-tel-i
     bind:value
     bind:valid
     bind:detailedValue
-    class="basic-tel-input {!isValid ? 'invalid' : ''}"
+    class="basic-tel-input {!valid ? 'invalid' : ''}"
   />
 </div>
 

--- a/packages/svelte-tel-input/README.md
+++ b/packages/svelte-tel-input/README.md
@@ -63,12 +63,12 @@ _Snippet would be too long_ - [Example](https://github.com/gyurielf/svelte-tel-i
     name="Country"
     bind:value={selectedCountry}
   >
-    <option value={null} hidden={country !== null}>Please select</option>
+    <option value={null} hidden={selectedCountry !== null}>Please select</option>
     {#each normalizedCountries as currentCountry (currentCountry.id)}
       <option
         value={currentCountry.iso2}
-        selected={currentCountry.iso2 === country}
-        aria-selected={currentCountry.iso2 === country}
+        selected={currentCountry.iso2 === selectedCountry}
+        aria-selected={currentCountry.iso2 === selectedCountry}
       >
         {currentCountry.iso2} (+{currentCountry.dialCode})
       </option>


### PR DESCRIPTION
Defined with `let valid = true;`

but used `isValid`